### PR TITLE
Add ladder tournament format

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
               <option value="fixed">Fixed Partner Tournament</option>
               <option value="rotating">Rotating Partner Tournament</option>
               <option value="free">Free Game Tournament (manual schedule)</option>
+              <option value="ladder">Ladder Tournament</option>
               <option value="playoff">Playoff Bracket Tournament</option>
             </select>
           </label>
@@ -93,6 +94,13 @@
               <!-- Hidden input to store selected number of players -->
               <!-- Allow up to 16 players for rotating tournaments, including odd numbers.  -->
               <input type="number" id="rotating-players" min="4" max="16" value="4" class="hidden">
+            </label>
+          </div>
+          <div id="ladder-options" class="tournament-options hidden">
+            <label>
+              Number of players (8, 12 or 16):
+              <div id="ladder-players-options" class="options-buttons"></div>
+              <input type="number" id="ladder-players" min="8" max="16" step="4" value="8" class="hidden">
             </label>
           </div>
       <div id="playoff-options" class="tournament-options hidden">
@@ -160,6 +168,7 @@
         <!-- Button to add a second leg of matches for fixed partner tournaments -->
         <!-- Button for adding a second leg of matches in fixed partner tournaments -->
         <button id="second-round-btn" class="btn accent hidden" style="margin-top:0.5rem;">Add Second Leg</button>
+        <button id="new-round-btn" class="btn accent hidden" style="margin-top:0.5rem;">New Round</button>
         <!-- Button to finish the tournament and show final classification -->
         <button id="finish-tournament-btn" class="btn primary hidden" style="margin-top:0.5rem;">Finish Tournament</button>
         <div id="schedule"></div>


### PR DESCRIPTION
## Summary
- support Ladder tournaments on config screen
- generate ladder rounds, rankings, and movement logic
- show "New Round" button for ladder events

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68878e080ea88327b4c941cb71ee66b4