### PR TITLE
Add ladder tournament ranking

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
               <option value="match">Official Match (4 players)</option>
               <option value="fixed">Fixed Partner Tournament</option>
               <option value="rotating">Rotating Partner Tournament</option>
+              <option value="ladder">Ladder Tournament</option>
               <option value="free">Free Game Tournament (manual schedule)</option>
               <option value="playoff">Playoff Bracket Tournament</option>
             </select>


### PR DESCRIPTION
## Summary
- add Ladder Tournament option
- compute ladder rankings with points, wins and matches
- display Ladder ranking table and podium
- allow manual match entry for ladder tournaments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688794d476548327a081aad47391e70b